### PR TITLE
ZEN-2826 - Cleanup and simplification of FeatureHelper

### DIFF
--- a/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/FeatureHelper.xtend
+++ b/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/FeatureHelper.xtend
@@ -8,38 +8,31 @@
  *******************************************************************************/
 package com.modelsolv.reprezen.gentemplates.xsdelement.xtend
 
-import com.modelsolv.reprezen.restapi.datatypes.Feature
-import com.modelsolv.reprezen.restapi.datatypes.ReferenceElement
-import com.modelsolv.reprezen.restapi.datatypes.PrimitiveProperty
-import com.modelsolv.reprezen.restapi.ReferenceLink
-import com.modelsolv.reprezen.restapi.datatypes.Structure
-import com.modelsolv.reprezen.restapi.ServiceDataResource
-import com.modelsolv.reprezen.restapi.TypedMessage
-import com.modelsolv.reprezen.restapi.datatypes.ReferenceProperty
-import com.modelsolv.reprezen.restapi.PropertyReference
-import com.modelsolv.reprezen.restapi.SourceReference
-import com.modelsolv.reprezen.restapi.PrimitiveTypeSourceReference
-import com.modelsolv.reprezen.gentemplates.common.services.CommonServices
 import com.google.common.collect.Iterables
-import com.modelsolv.reprezen.restapi.datatypes.PrimitiveType
+import com.modelsolv.reprezen.restapi.PropertyRealization
+import com.modelsolv.reprezen.restapi.ReferenceLink
 import com.modelsolv.reprezen.restapi.ResourceAPI
 import com.modelsolv.reprezen.restapi.datatypes.DataModel
-import com.modelsolv.reprezen.restapi.PropertyRealization
+import com.modelsolv.reprezen.restapi.datatypes.Feature
+import com.modelsolv.reprezen.restapi.datatypes.PrimitiveProperty
+import com.modelsolv.reprezen.restapi.datatypes.PrimitiveType
+import com.modelsolv.reprezen.restapi.datatypes.ReferenceElement
+import com.modelsolv.reprezen.restapi.datatypes.ReferenceProperty
+import com.modelsolv.reprezen.restapi.datatypes.Structure
 
 class FeatureHelper {
 	extension XMLSchemaHelper = new XMLSchemaHelper
 	val static UNBOUNDED = 'unbounded'
-	val commonServices = new CommonServices
 
-	def dispatch isRequired(Feature feature) {
+	def dispatch boolean isRequired(Feature feature) {
 		feature.minOccurs > 0
 	}
 
-	def dispatch isRequired(ReferenceElement feature) {
+	def dispatch boolean isRequired(ReferenceElement feature) {
 		feature.minOccurs > 0
 	}
 
-	def dispatch isRequired(PropertyRealization includedProperty) {
+	def dispatch boolean isRequired(PropertyRealization includedProperty) {
 		includedProperty.minOccurs > 0
 	}
 
@@ -109,71 +102,37 @@ class FeatureHelper {
 		if(feature.maxOccurs != -1) feature.maxOccurs.normalizedMaxOccurs else UNBOUNDED
 	}
 
-	def dispatch Iterable<Feature> getSequenceProperties(Structure dataType) {
-		dataType.ownedFeatures.sequenceProperties.map[it as Feature]
-	}
-
-	def dispatch Iterable<PropertyRealization> getSequenceProperties(ServiceDataResource dataResource) {
-		Iterables.concat(dataResource.type.ownedFeatures.referenceProperties.map[it as PropertyRealization],
-			dataResource.primitiveMultiProperties.map[it as PropertyRealization])
-	}
-
-	def dispatch Iterable<PropertyRealization> getSequenceProperties(TypedMessage message) {
-		Iterables.concat(message.actualType.ownedFeatures.referenceProperties.map[it as PropertyRealization],
-			message.primitiveMultiProperties.map[it as PropertyRealization])
-	}
-
-	def dispatch Iterable<Feature> getSequenceProperties(Iterable<Feature> features) {
-		Iterables.concat(features.referenceProperties.map[it as Feature],
-			features.primitiveMultiProperties.map[it as Feature])
-	}
-
 	def Iterable<PrimitiveProperty> getPrimitiveProperties(Iterable<Feature> features) {
 		features.filter[it.isPrimitiveProperty].map[it as PrimitiveProperty]
 	}
 
-	def dispatch Iterable<ReferenceProperty> getReferenceProperties(Iterable<Feature> features) {
+	def Iterable<ReferenceProperty> getReferenceProperties(Iterable<Feature> features) {
 		features.filter[it instanceof ReferenceProperty].map[it as ReferenceProperty]
-	}
-
-	def dispatch Iterable<PropertyRealization> getReferenceProperties(ServiceDataResource dataResource) {
-		dataResource.includedProperties.filter[isReferenceProperty(it.baseProperty)]
-	}
-
-	def dispatch Iterable<PropertyRealization> getReferenceProperties(TypedMessage message) {
-		message.includedProperties.filter[isReferenceProperty(it.baseProperty)]
 	}
 
 	def isPrimitiveProperty(Feature feature) {
 		feature instanceof PrimitiveProperty
 	}
 
-	def dispatch Iterable<PrimitiveProperty> getPrimitiveMultiProperties(Iterable<Feature> features) {
+	def Iterable<PrimitiveProperty> getPrimitiveMultiProperties(Iterable<Feature> features) {
 		features.filter[it.isMultiValued].primitiveProperties
 	}
 
-	def dispatch Iterable<PropertyRealization> getPrimitiveMultiProperties(ServiceDataResource dataResource) {
-		dataResource.includedProperties.filter[isPrimitiveProperty(it.baseProperty) && it.isMultiValued]
-	}
-
-	def dispatch Iterable<PropertyRealization> getPrimitiveMultiProperties(TypedMessage message) {
-		message.includedProperties.filter[isPrimitiveProperty(it.baseProperty) && it.isMultiValued]
-	}
-
-	def Iterable<PrimitiveProperty> getPrimitiveSimpleProperties(Iterable<Feature> features) {
+	def Iterable<PrimitiveProperty> getPrimitiveSingleProperties(Iterable<Feature> features) {
 		features.primitiveProperties.filter[!it.isMultiValued]
 	}
 
-	def dispatch hasSequenceProperties(Iterable<Feature> features) {
+	def hasSequenceProperties(Iterable<Feature> features) {
 		!features.sequenceProperties.nullOrEmpty
 	}
 
-	def dispatch hasSequenceProperties(ServiceDataResource dataResource) {
-		!dataResource.sequenceProperties.nullOrEmpty
+	def private dispatch Iterable<Feature> getSequenceProperties(Structure dataType) {
+		dataType.ownedFeatures.sequenceProperties.map[it as Feature]
 	}
 
-	def dispatch hasSequenceProperties(TypedMessage message) {
-		!message.sequenceProperties.nullOrEmpty
+	def private dispatch Iterable<Feature> getSequenceProperties(Iterable<Feature> features) {
+		Iterables.concat(features.referenceProperties.map[it as Feature],
+			features.primitiveMultiProperties.map[it as Feature])
 	}
 
 	def dispatch isMultiValued(Feature feature) {
@@ -188,56 +147,12 @@ class FeatureHelper {
 		(feature.maxOccurs > 1) || (feature.maxOccurs == -1)
 	}
 
-	def isPrimitivePropertyReference(PropertyReference featureReference) {
-		featureReference.conceptualFeature.isPrimitiveProperty
-	}
-
-	def isPrimitiveSourceReference(SourceReference sourceReference) {
-		if (sourceReference instanceof PropertyReference)
-			(sourceReference as PropertyReference).isPrimitivePropertyReference
-		else
-			sourceReference instanceof PrimitiveTypeSourceReference
-	}
-
-	def isReferencePropertyReference(PropertyReference featureReference) {
-		featureReference.conceptualFeature.isReferenceProperty
-	}
-
-	def isReferenceProperty(Feature feature) {
-		feature instanceof ReferenceProperty
-	}
-
-	def isReferenceSourceReference(SourceReference sourceReference) {
-		if (sourceReference instanceof PropertyReference)
-			(sourceReference as PropertyReference).isReferencePropertyReference
-		else
-			false
-	}
-
 	def public normalizedMaxOccurs(Integer value) {
 		if(value == 0) 1 else value
 	}
 
-	def primitiveFeatureType(PrimitiveProperty primitiveProperty) {
+	def private primitiveFeatureType(PrimitiveProperty primitiveProperty) {
 		primitiveProperty.type.name
 	}
 
-	def referenceFeatureType(ReferenceProperty referenceProperty) {
-		referenceProperty.type.name
-	}
-
-	def featureType(Feature feature) {
-		if (feature.isPrimitiveProperty)
-			(feature as PrimitiveProperty).primitiveFeatureType
-		else
-			(feature as ReferenceProperty).referenceFeatureType
-	}
-
-	def getPrettyPrintedMultiplicity(Feature feature) {
-		commonServices.getPrettyPrintedMultiplicity(feature)
-	}
-
-	def getPrettyPrintedCardinality(PropertyRealization includedProperty) {
-		commonServices.getPrettyPrintedCardinality(includedProperty)
-	}
 }

--- a/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/PropertyRealizationHelper.xtend
+++ b/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/PropertyRealizationHelper.xtend
@@ -20,20 +20,6 @@ class PropertyRealizationHelper {
 	
 	extension FeatureHelper = new FeatureHelper
 
-	def private dispatch Iterable<PropertyRealization> getSequencePropRzs(ServiceDataResource dataResource) {
-		dataResource.includedProperties.getSequencePropRzs
-	}
-
-	def private dispatch Iterable<PropertyRealization> getSequencePropRzs(TypedMessage message) {
-		message.includedProperties.getSequencePropRzs
-	}
-
-	def private dispatch Iterable<PropertyRealization> getSequencePropRzs(Iterable<PropertyRealization> features) {
-		Iterables.concat(
-			features.referencePropRzs,
-			features.primitiveMultiPropRzs)
-	}
-
 	def dispatch Iterable<PropertyRealization> getReferencePropRzs(Iterable<PropertyRealization> features) {
 		features.filter[it.baseProperty instanceof ReferenceProperty]
 	}
@@ -50,27 +36,33 @@ class PropertyRealizationHelper {
 		features.filter[it.baseProperty instanceof PrimitiveProperty]
 	}
 	
-	def dispatch Iterable<PropertyRealization> getPrimitiveMultiPropRzs(Iterable<PropertyRealization> features) {
+	def Iterable<PropertyRealization> getPrimitiveMultiPropRzs(Iterable<PropertyRealization> features) {
 		features.primitivePropRzs.filter[it.isMultiValued]
 	}
 
-	def dispatch Iterable<PropertyRealization> getPrimitiveMultiPropRzs(ServiceDataResource dataResource) {
+	def Iterable<PropertyRealization> getPrimitiveMultiPropRzs(ServiceDataResource dataResource) {
 		dataResource.includedProperties.primitiveMultiPropRzs
 	}
 
-	def dispatch Iterable<PropertyRealization> getPrimitiveMultiPropRzs(TypedMessage message) {
+	def Iterable<PropertyRealization> getPrimitiveMultiPropRzs(TypedMessage message) {
 		message.includedProperties.primitiveMultiPropRzs
 	}
 
-	def dispatch boolean hasSequencePropRzs(Iterable<PropertyRealization> features) {
-		!features.sequencePropRzs.nullOrEmpty
-	}
-
-	def dispatch boolean hasSequencePropRzs(ServiceDataResource dataResource) {
+	def boolean hasSequencePropRzs(ServiceDataResource dataResource) {
 		dataResource.includedProperties.hasSequencePropRzs
 	}
 
-	def dispatch boolean hasSequencePropRzs(TypedMessage message) {
+	def boolean hasSequencePropRzs(TypedMessage message) {
 		message.includedProperties.hasSequencePropRzs
+	}
+
+	def boolean hasSequencePropRzs(Iterable<PropertyRealization> features) {
+		!features.sequencePropRzs.nullOrEmpty
+	}
+
+	def private Iterable<PropertyRealization> getSequencePropRzs(Iterable<PropertyRealization> features) {
+		Iterables.concat(
+			features.referencePropRzs,
+			features.primitiveMultiPropRzs)
 	}
 }

--- a/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/PropertyRealizationHelper.xtend
+++ b/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/PropertyRealizationHelper.xtend
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright © 2013, 2016 Modelsolv, Inc.
+ * All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains the property
+ * of ModelSolv, Inc. See the file license.html in the root directory of
+ * this project for further information.
+ *******************************************************************************/
+
+package com.modelsolv.reprezen.gentemplates.xsdelement.xtend
+
+import com.google.common.collect.Iterables
+import com.modelsolv.reprezen.restapi.PropertyRealization
+import com.modelsolv.reprezen.restapi.ServiceDataResource
+import com.modelsolv.reprezen.restapi.TypedMessage
+import com.modelsolv.reprezen.restapi.datatypes.PrimitiveProperty
+import com.modelsolv.reprezen.restapi.datatypes.ReferenceProperty
+
+class PropertyRealizationHelper {
+	
+	extension FeatureHelper = new FeatureHelper
+
+	def private dispatch Iterable<PropertyRealization> getSequencePropRzs(ServiceDataResource dataResource) {
+		dataResource.includedProperties.getSequencePropRzs
+	}
+
+	def private dispatch Iterable<PropertyRealization> getSequencePropRzs(TypedMessage message) {
+		message.includedProperties.getSequencePropRzs
+	}
+
+	def private dispatch Iterable<PropertyRealization> getSequencePropRzs(Iterable<PropertyRealization> features) {
+		Iterables.concat(
+			features.referencePropRzs,
+			features.primitiveMultiPropRzs)
+	}
+
+	def dispatch Iterable<PropertyRealization> getReferencePropRzs(Iterable<PropertyRealization> features) {
+		features.filter[it.baseProperty instanceof ReferenceProperty]
+	}
+
+	def dispatch Iterable<PropertyRealization> getReferencePropRzs(ServiceDataResource dataResource) {
+		dataResource.includedProperties.referencePropRzs
+	}
+
+	def dispatch Iterable<PropertyRealization> getReferencePropRzs(TypedMessage message) {
+		message.includedProperties.referencePropRzs
+	}
+	
+	def private Iterable<PropertyRealization> getPrimitivePropRzs(Iterable<PropertyRealization> features) {
+		features.filter[it.baseProperty instanceof PrimitiveProperty]
+	}
+	
+	def dispatch Iterable<PropertyRealization> getPrimitiveMultiPropRzs(Iterable<PropertyRealization> features) {
+		features.primitivePropRzs.filter[it.isMultiValued]
+	}
+
+	def dispatch Iterable<PropertyRealization> getPrimitiveMultiPropRzs(ServiceDataResource dataResource) {
+		dataResource.includedProperties.primitiveMultiPropRzs
+	}
+
+	def dispatch Iterable<PropertyRealization> getPrimitiveMultiPropRzs(TypedMessage message) {
+		message.includedProperties.primitiveMultiPropRzs
+	}
+
+	def dispatch boolean hasSequencePropRzs(Iterable<PropertyRealization> features) {
+		!features.sequencePropRzs.nullOrEmpty
+	}
+
+	def dispatch boolean hasSequencePropRzs(ServiceDataResource dataResource) {
+		dataResource.includedProperties.hasSequencePropRzs
+	}
+
+	def dispatch boolean hasSequencePropRzs(TypedMessage message) {
+		message.includedProperties.hasSequencePropRzs
+	}
+}

--- a/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/XGenerateResourceAPI.xtend
+++ b/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/XGenerateResourceAPI.xtend
@@ -33,6 +33,7 @@ import com.modelsolv.reprezen.restapi.PropertyRealization
 
 class XGenerateResourceAPI extends ZenModelExtractOutputItem<ResourceAPI> {
 	extension FeatureHelper = new FeatureHelper
+	extension PropertyRealizationHelper = new PropertyRealizationHelper
 	extension ResourceHelper = new ResourceHelper
 	extension ReferenceLinkHelper = new ReferenceLinkHelper
 	extension XMLSchemaHelper = new XMLSchemaHelper
@@ -143,13 +144,13 @@ class XGenerateResourceAPI extends ZenModelExtractOutputItem<ResourceAPI> {
 		'''
 			<xs:complexType name="«message.messageTypeName»">
 			«complexType.generateXSDDoc»
-			«IF message.hasSequenceProperties»
+			«IF message.hasSequencePropRzs»
 				<xs:sequence>
-				«FOR feature : message.getReferenceProperties SEPARATOR ""»
-					«(feature as PropertyRealization).generateMessageTypeReferenceProperty(message, resourceAPI, new LinkedList())»
+				«FOR feature : message.getReferencePropRzs SEPARATOR ""»
+					«feature.generateMessageTypeReferenceProperty(message, resourceAPI, new LinkedList())»
 				«ENDFOR»
-				«FOR feature : message.getPrimitiveMultiProperties SEPARATOR ""»
-					«(feature as PropertyRealization).generatePrimitiveProperty(resourceAPI)»
+				«FOR feature : message.getPrimitiveMultiPropRzs SEPARATOR ""»
+					«feature.generatePrimitiveProperty(resourceAPI)»
 				«ENDFOR»
 				«FOR referenceLink : message.getReferenceLinks»
 					«referenceLink.generateReferenceSegment(resourceAPI)»
@@ -205,12 +206,12 @@ class XGenerateResourceAPI extends ZenModelExtractOutputItem<ResourceAPI> {
 				«ENDFOR»
 				</xs:sequence>
 			«ELSE»
-				«IF dataResource.hasSequenceProperties»
+				«IF dataResource.hasSequencePropRzs»
 					<xs:sequence>
-					«FOR feature : dataResource.getReferenceProperties SEPARATOR ""»
+					«FOR feature : dataResource.getReferencePropRzs SEPARATOR ""»
 						«feature.generateReferenceProperty(dataResource, resourceAPI, #[])»
 					«ENDFOR»
-					«FOR feature : dataResource.getPrimitiveMultiProperties SEPARATOR ""»
+					«FOR feature : dataResource.getPrimitiveMultiPropRzs SEPARATOR ""»
 						«feature.generatePrimitiveProperty(resourceAPI)»
 					«ENDFOR»
 					«FOR referenceLink : dataResource.getReferenceLinks SEPARATOR ""»
@@ -252,7 +253,7 @@ class XGenerateResourceAPI extends ZenModelExtractOutputItem<ResourceAPI> {
 										«ENDIF»
 									</xs:sequence>
 									«IF linkDescriptor != null»
-										«FOR feature : linkDescriptor.includedFeatures.getPrimitiveSimpleProperties»
+										«FOR feature : linkDescriptor.includedFeatures.getPrimitiveSingleProperties»
 											«feature.generatePrimitiveProperty(resourceAPI)»
 										«ENDFOR»
 									«ENDIF»
@@ -274,7 +275,7 @@ class XGenerateResourceAPI extends ZenModelExtractOutputItem<ResourceAPI> {
 							«ENDIF»
 						</xs:sequence>
 						«IF linkDescriptor != null»
-							«FOR feature : linkDescriptor.includedFeatures.getPrimitiveSimpleProperties»
+							«FOR feature : linkDescriptor.includedFeatures.getPrimitiveSingleProperties»
 								«feature.generatePrimitiveProperty(resourceAPI)»
 							«ENDFOR»
 						«ENDIF»


### PR DESCRIPTION
This is a cleanup and (hopefully) a simplification of FeatureHelper, which had some messy and confusing multiple-dispatch extension methods. 
- Eliminated overloaded extension methods that were returning different types. FeatureHelper has methods that return data structures, properties or features. Methods that return property realizations are moved to PropertyRealizationHelper.
- Also removed unused methods, and marked as private a few methods that are only used internally in the helper classes.
- Centralized some of the filtering logic, to make the code more DRY.
