### PR TITLE
Xsd Element changes

### DIFF
--- a/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/XMLSchemaGenTemplate.java
+++ b/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/XMLSchemaGenTemplate.java
@@ -12,6 +12,7 @@ import com.modelsolv.reprezen.core.xml.XmlFormatter;
 import com.modelsolv.reprezen.generators.api.GenerationException;
 import com.modelsolv.reprezen.generators.api.template.GenTemplate;
 import com.modelsolv.reprezen.generators.api.zenmodel.ZenModelGenTemplate;
+import com.modelsolv.reprezen.gentemplates.xsdelement.XMLSchemaGenTemplate.Generator;
 import com.modelsolv.reprezen.gentemplates.xsdelement.xtend.XGenerateDataModel;
 import com.modelsolv.reprezen.gentemplates.xsdelement.xtend.XGenerateResourceAPI;
 import com.modelsolv.reprezen.restapi.ZenModel;
@@ -27,7 +28,7 @@ public class XMLSchemaGenTemplate extends ZenModelGenTemplate {
 
     @Override
     public String getName() {
-        return "XML Schema (Element)"; //$NON-NLS-1$
+        return "Pioneer Research Model"; //$NON-NLS-1$
     }
 
     @Override

--- a/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/FeatureHelper.xtend
+++ b/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/FeatureHelper.xtend
@@ -37,7 +37,8 @@ class FeatureHelper {
 	}
 
 	def getReferenceItemName(ReferenceElement referenceElement) {
-		referenceElement.dataType.name.toFirstLower
+		//referenceElement.dataType.name.toFirstLower
+		referenceElement.name.toFirstLower
 	}
 
 	def getReferenceElementName(ReferenceElement referenceElement) {
@@ -79,15 +80,15 @@ class FeatureHelper {
 	}
 
 	def dispatch getListItemMinOccurs(Feature feature) {
-		if(feature.minOccurs > 1) feature.minOccurs else 1
+		if(feature.minOccurs >= 1) feature.minOccurs else 0
 	}
 
 	def dispatch getListItemMinOccurs(ReferenceElement feature) {
-		if(feature.minOccurs > 1) feature.minOccurs else 1
+		if(feature.minOccurs >= 1) feature.minOccurs else 0
 	}
 
 	def dispatch getListItemMinOccurs(PropertyRealization feature) {
-		if(feature.minOccurs > 1) feature.minOccurs else 1
+		if(feature.minOccurs >= 1) feature.minOccurs else 0
 	}
 
 	def dispatch getListItemMaxOccurs(Feature feature) {

--- a/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/XMLSchemaHelper.xtend
+++ b/XSDElement/src/main/java/com/modelsolv/reprezen/gentemplates/xsdelement/xtend/XMLSchemaHelper.xtend
@@ -12,28 +12,28 @@ import com.google.common.base.Splitter
 import com.google.common.base.Strings
 import com.google.common.collect.Lists
 import com.modelsolv.reprezen.gentemplates.common.services.CommonServices
-import com.modelsolv.reprezen.gentemplates.common.xtend.ZenModelHelper
-import com.modelsolv.reprezen.restapi.Documentable
 import com.modelsolv.reprezen.restapi.Method
 import com.modelsolv.reprezen.restapi.ResourceAPI
 import com.modelsolv.reprezen.restapi.ResourceDefinition
 import com.modelsolv.reprezen.restapi.ServiceDataResource
 import com.modelsolv.reprezen.restapi.TypedMessage
 import com.modelsolv.reprezen.restapi.ZenModel
-import com.modelsolv.reprezen.restapi.datatypes.Constraint
 import com.modelsolv.reprezen.restapi.datatypes.DataModel
-import com.modelsolv.reprezen.restapi.datatypes.LengthConstraint
 import com.modelsolv.reprezen.restapi.datatypes.PrimitiveType
 import com.modelsolv.reprezen.restapi.datatypes.ReferenceProperty
-import com.modelsolv.reprezen.restapi.datatypes.RegExConstraint
 import com.modelsolv.reprezen.restapi.datatypes.SingleValueType
 import com.modelsolv.reprezen.restapi.datatypes.Structure
 import com.modelsolv.reprezen.restapi.datatypes.UserDefinedType
-import com.modelsolv.reprezen.restapi.datatypes.ValueRangeConstraint
 import java.util.Collection
 import java.util.LinkedList
 import java.util.Set
 import org.eclipse.emf.ecore.EObject
+import com.modelsolv.reprezen.restapi.Documentable
+import com.modelsolv.reprezen.gentemplates.common.xtend.ZenModelHelper
+import com.modelsolv.reprezen.restapi.datatypes.Constraint
+import com.modelsolv.reprezen.restapi.datatypes.LengthConstraint
+import com.modelsolv.reprezen.restapi.datatypes.RegExConstraint
+import com.modelsolv.reprezen.restapi.datatypes.ValueRangeConstraint
 
 class XMLSchemaHelper {
 	extension ZenModelHelper zenModelHelper = new ZenModelHelper


### PR DESCRIPTION
Really rough modifications to get things working for a JSON-derived XSD model internal to my organization.

Main differences:
Elements preferred over attributes
<xs:all> wrapper around a series of elements to allow out-of-order operations
"optional" attributes become min=0 elements

Feature yet to implement: Provide a name for the XML root element: it defaults to a generated name based on the model, I'd like to set a preferred name (JSON has no name on root element so we use a default in our translation)